### PR TITLE
[16.0][FIX] sale_stock_deposit_mgmt: Context deposits from partner form

### DIFF
--- a/sale_stock_deposit_mgmt/models/res_partner.py
+++ b/sale_stock_deposit_mgmt/models/res_partner.py
@@ -14,7 +14,7 @@ class ResPartner(models.Model):
             {
                 "no_at_date": True,
                 "search_default_on_hand": True,
-                "force_restricted_owner_id": self.id,
+                "force_restricted_owner_id": self,
             }
         )
         return self.env["stock.quant"].with_context(**ctx)._get_quants_action(domain)

--- a/sale_stock_deposit_mgmt/views/res_partner_views.xml
+++ b/sale_stock_deposit_mgmt/views/res_partner_views.xml
@@ -8,7 +8,7 @@
                 <button
                     class="oe_stat_button"
                     type="object"
-                    context="{'default_owner_id': active_id, 'force_restricted_owner_id': active_id}"
+                    context="{'default_owner_id': active_id}"
                     name="action_open_owner_quants"
                     icon="fa-cubes"
                 >


### PR DESCRIPTION
En https://github.com/OCA/stock-logistics-workflow/blob/16.0/stock_owner_restriction/models/stock_quant.py#L32 se compara con un res.partner, no con el id, por lo que debería pasarse por context el objeto y no el id.

Esto corrige el error al intentar validar un albarán que se cree desde el smart button de depósitos en el formulario de clientes.


@moduon MT-3404